### PR TITLE
Add hello endpoint with Spring Boot and virtual threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency>

--- a/src/main/java/co/thirtyroses/ai/lucien/HelloController.java
+++ b/src/main/java/co/thirtyroses/ai/lucien/HelloController.java
@@ -5,9 +5,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 class HelloController {
-
     @GetMapping("/hello")
     HelloResponse hello() {
         return new HelloResponse("world");
     }
+
 }
+
+record HelloResponse(String message) {}

--- a/src/main/java/co/thirtyroses/ai/lucien/HelloController.java
+++ b/src/main/java/co/thirtyroses/ai/lucien/HelloController.java
@@ -1,0 +1,13 @@
+package co.thirtyroses.ai.lucien;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class HelloController {
+
+    @GetMapping("/hello")
+    HelloResponse hello() {
+        return new HelloResponse("world");
+    }
+}

--- a/src/main/java/co/thirtyroses/ai/lucien/HelloResponse.java
+++ b/src/main/java/co/thirtyroses/ai/lucien/HelloResponse.java
@@ -1,0 +1,3 @@
+package co.thirtyroses.ai.lucien;
+
+record HelloResponse(String message) {}

--- a/src/main/java/co/thirtyroses/ai/lucien/HelloResponse.java
+++ b/src/main/java/co/thirtyroses/ai/lucien/HelloResponse.java
@@ -1,3 +1,0 @@
-package co.thirtyroses.ai.lucien;
-
-record HelloResponse(String message) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: Lucien AI
+  threads:
+    virtual:
+      enabled: true
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}

--- a/src/test/java/co/thirtyroses/ai/lucien/HelloControllerTest.java
+++ b/src/test/java/co/thirtyroses/ai/lucien/HelloControllerTest.java
@@ -1,0 +1,24 @@
+package co.thirtyroses.ai.lucien;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HelloController.class)
+class HelloControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void hello_shouldReturnExpectedJson() throws Exception {
+        mockMvc.perform(get("/hello"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.message").value("world"));
+    }
+}

--- a/src/test/java/co/thirtyroses/ai/lucien/HelloControllerTest.java
+++ b/src/test/java/co/thirtyroses/ai/lucien/HelloControllerTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HelloController.class)
 class HelloControllerTest {
-
     @Autowired
     private MockMvc mockMvc;
 


### PR DESCRIPTION
## Summary
- Add `spring-boot-starter-web` dependency for REST API support
- Enable Java virtual threads via `spring.threads.virtual.enabled=true` configuration
- Implement minimal `/hello` endpoint returning `{"message":"world"}` JSON response
- Create `HelloResponse` record for type-safe JSON serialization
- Add comprehensive integration test using MockMvc
- Verify application startup and endpoint functionality

## Test plan
- [x] Unit/integration tests pass (`./mvnw test`)  
- [x] Application starts successfully (`./mvnw spring-boot:run`)
- [x] GET `/hello` endpoint returns expected JSON: `{"message":"world"}`
- [x] Application runs on port 8080 with embedded Tomcat
- [x] Virtual threads enabled in Spring Boot configuration
- [x] Code follows established project patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)